### PR TITLE
Don't use network host mode in the example docker-compose.yaml

### DIFF
--- a/example/containerized/docker-compose.yaml
+++ b/example/containerized/docker-compose.yaml
@@ -12,9 +12,12 @@ services:
   shortumation:
     # make sure to replace the ARCH with whatever system you are running!
     image: "asosnovsky/shortumation-${ARCH:-amd64}:${SHORTUMATION_VERSION:-latest}"
-    network_mode: host
+    ports:
+      - 8000:8000
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./config:/config
     environment:
       - SUPERVISOR_TOKEN=${SUPERVISOR_TOKEN}
-      - HASSIO_WS=ws://0.0.0.0:8123/api/websocket
+      - HASSIO_WS=ws://host.docker.internal:8123/api/websocket


### PR DESCRIPTION
There is no need to attach this container to the host network if it only needs to connect to home-assistant which runs in the host mode itself. Host mode gives unlimited access to the host network, so it is more secure to restrict this container to just what it needs.